### PR TITLE
Fix settings example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you are using either WordPress plugin or Drupal module, you can change the Sk
 
 ```html
 <script>
-var skipToConfig =
+var SkipToConfig =
 {
 	"settings": {
 		"skipTo": {


### PR DESCRIPTION
Script expects SkipToConfig global variable, starting with capital S.