### PR TITLE
Update deps to latest versions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
 			'<%= grunt.template.today("yyyy-mm-dd") %>\n' +
 			'<%= pkg.homepage ? "* " + pkg.homepage + "\\n" : "" %>' +
 			'* Copyright (c) <%= grunt.template.today("yyyy") %> <%= pkg.author %>;' +
-			' Licensed <%= _.pluck(pkg.licenses, "type").join(", ") %> */\n' ,
+			' Licensed <%= _.map(pkg.licenses, "type").join(", ") %> */\n' ,
 
 		bannerCond:	
 			'/*@cc_on @*/\n' +

--- a/package.json
+++ b/package.json
@@ -19,19 +19,22 @@
       "url": "https://github.com/paypal/skipto/blob/master/BSDLicense.txt"
     }
   ],
+  "engines": {
+    "node": ">=6"
+  },
   "devDependencies": {
-    "jshint": "~1.1.0",
+    "jshint": "~2.10.2",
     "uglify-js": "~2.8.0",
-    "less": "~1.3.3",
-    "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.6.5",
-    "grunt-contrib-less": "~0.5.2",
-    "grunt-contrib-uglify": "~0.2.7",
-    "grunt-replace": "~0.4.4",
-    "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-compress": "~0.5.2",
-    "grunt-contrib-clean": "~0.4.1",
-    "grunt-contrib-concat": "~0.3.0"
+    "less": "^3.0.4",
+    "grunt": "^1.0.4",
+    "grunt-contrib-jshint": "~2.1.0",
+    "grunt-contrib-less": "~2.0.0",
+    "grunt-contrib-uglify": "~4.0.1",
+    "grunt-replace": "~1.0.1",
+    "grunt-contrib-copy": "~1.0.0",
+    "grunt-contrib-compress": "~1.4.3",
+    "grunt-contrib-clean": "~2.0.0",
+    "grunt-contrib-concat": "~1.0.1"
   },
   "readmeFilename": "README.md",
   "gitHead": "641457dfeea57fbedfba5ba2a65ce0c33ac411b7",
@@ -39,20 +42,6 @@
   "directories": {
     "example": "example",
     "test": "test"
-  },
-  "dependencies": {
-    "grunt": "~0.4.2",
-    "grunt-contrib-clean": "~0.4.1",
-    "grunt-contrib-compress": "~0.5.2",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-jshint": "~0.6.5",
-    "grunt-contrib-uglify": "~0.2.7",
-    "grunt-contrib-less": "~0.5.2",
-    "grunt-replace": "~0.4.4",
-    "jshint": "~1.1.0",
-    "less": "~1.3.3",
-    "uglify-js": "~2.8.0"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
Updates dependencies to latest versions

- Removes node warnings of vulnerabilities in old versions of grunt
- There are small changes to generated packages (e.g. sass has some extra spaces, there's also some subtle differences in the compiled JS) - I haven't committed them as I wasn't sure if you guys only do this at run time.
- Small tweak to build script due to loadash replacing the `pluck` method - the new method is 1:1 b/c https://stackoverflow.com/questions/35136306/what-happened-to-lodash-pluck 
- Removed everything as a dependency - they should either be a devDep OR a dep not both imo. I chose to make them dev deps - but can make them real deps if that's the preferred option too