### PR TITLE
fix: Add explicit Jekyll theme 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 markdown: kramdown
+theme: jekyll-theme-slate


### PR DESCRIPTION
Noticed on my fork that it wasn't rendering correctly for the fork because it didn't know what theme it was using.
Found the one currently used here in the CSS and made it explicit