### PR TITLE
chore: Format HTML and HTTP links

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,26 +1,30 @@
 <!DOCTYPE html>
 <html>
+
 	<head>
-		<meta charset='utf-8' />
+		<meta charset="utf-8" />
 		<meta http-equiv="X-UA-Compatible" content="chrome=1" />
-		<meta name="description" content="SkipTo is a replacement for your old classic Skipnav link,! The SkipTo script creates a drop-down menu consisting of the links to the important places on a given web page. The menu will make it easier for keyboard and screen reader users to quickly jump to the desired location by simply choosing it from the list of options."/>
+		<meta name="description" content="SkipTo is a replacement for your old classic Skipnav link,! The SkipTo script creates a drop-down menu consisting of the links to the important places on a given web page. The menu will make it easier for keyboard and screen reader users to quickly jump to the desired location by simply choosing it from the list of options." />
 		<link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
-		<title>Skipto</title>
+		<title>SkipTo</title>
 	</head>
 
 	<body>
 		<!-- HEADER -->
 		<div id="header_wrap" class="outer">
-				<header class="inner" role="banner" style="max-width: 1076px;">
-					<a id="forkme_banner" href="https://github.com/paypal/skipto">View on GitHub</a>
-					<div>
-					<a href="http://paypal.github.io"><img src="images/accessibility_SkipTo_withedgewhite_transp.png" alt="Skip To Logo"></a>
-					<h1 id="project_title" style="display:inline; margin-left:10px;position:relative;top:-100px;">SkipTo plugin by PayPal Accessibility Team</h1>
-					<section id="downloads">
-						<a class="zip_download_link" href="https://github.com/paypal/skipto/zipball/master">Download this project as a .zip file</a>
-						<a class="tar_download_link" href="https://github.com/paypal/skipto/tarball/master">Download this project as a tar.gz file</a>
-					</section>
-				</header>
+			<header class="inner" role="banner" style="max-width: 1076px;">
+				<a id="forkme_banner" href="https://github.com/paypal/skipto">View on GitHub</a>
+				<a href="https://paypal.github.io"><img src="images/accessibility_SkipTo_withedgewhite_transp.png"
+						alt="Skip To Logo"></a>
+				<h1 id="project_title" style="display:inline; margin-left:10px;position:relative;top:-100px;">SkipTo
+					plugin by PayPal Accessibility Team</h1>
+				<section id="downloads">
+					<a class="zip_download_link" href="https://github.com/paypal/skipto/zipball/master">Download this
+						project as a .zip file</a>
+					<a class="tar_download_link" href="https://github.com/paypal/skipto/tarball/master">Download this
+						project as a tar.gz file</a>
+				</section>
+			</header>
 		</div>
 
 		<!-- MAIN CONTENT -->
@@ -28,19 +32,17 @@
 			<section id="main_content" class="inner" role="main">
 				{{ content }}
 
-
 				<h2>Downloads</h2>
-				<p>
-						<ol>
-						<li><a href="http://wordpress.org/plugins/skip-to/">Wordpress plugin zip</a></li>
-					  	<li><a href="https://drupal.org/project/SkipTo">Drupal plugin Tar</a></li>
-					  	<li><a href="./downloads/js/SkipTo.user.js">GreaseMonkey User Script</a></li>
-					  	<li>
-							<a href="javascript:(function(){var scr=document.createElement('SCRIPT');scr.type='text/javascript';scr.src='http://paypal.github.io/skipto/downloads/js/SkipTo.min.js?';document.getElementsByTagName('head')[0].appendChild(scr);})();">Skip To bookmarklet</a>
-						</li>	
-
-					  </ol>						
-				</p>	  
+				<ol>
+					<li><a href="https://wordpress.org/plugins/skip-to/">Wordpress plugin zip</a></li>
+					<li><a href="https://drupal.org/project/SkipTo">Drupal plugin Tar</a></li>
+					<li><a href="./downloads/js/SkipTo.user.js">GreaseMonkey User Script</a></li>
+					<li>
+						<a
+							href="javascript:(function(){var scr=document.createElement('SCRIPT');scr.type='text/javascript';scr.src='https://paypal.github.io/skipto/downloads/js/SkipTo.min.js?';document.getElementsByTagName('head')[0].appendChild(scr);})();">Skip
+							To bookmarklet</a>
+					</li>
+				</ol>
 			</section>
 		</div>
 
@@ -48,28 +50,26 @@
 		<div id="footer_wrap" class="outer" role="contentinfo">
 			<footer class="inner" role="contentinfo">
 				<p class="copyright">Skipto maintained by <a href="https://github.com/paypal">PayPal</a></p>
-				<p>Published with <a href="http://pages.github.com">GitHub Pages</a></p>				
+				<p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
 			</footer>
 		</div>
-<script>
-	var SkipToConfig =	{
-		"settings": {
-			"skipTo": {
-				"headings": "h1 ,h2, h3",
-				"landmarks": "[role=banner],[role=main],[role=search]",
-				"accesskey": "0",
-				"wrap": "true",
-				"visibility": "onLoad"
-			}
-		}
-	};
+		<script>
+			var SkipToConfig = {
+				"settings": {
+					"skipTo": {
+						"headings": "h1 ,h2, h3",
+						"landmarks": "[role=banner],[role=main],[role=search]",
+						"accesskey": "0",
+						"wrap": "true",
+						"visibility": "onLoad"
+					}
+				}
+			};
+		</script>
 
-</script>
-
-<script src="downloads/js/SkipTo.js"></script>
-<script>
-	skipToMenuInit(SkipToConfig)
-</script>
-
+		<script src="downloads/js/SkipTo.js"></script>
+		<script>
+			skipToMenuInit(SkipToConfig)
+		</script>
 	</body>
 </html>


### PR DESCRIPTION
- Got a few warnings around mixed content, so changed the links from HTTP to HTTPS
- ran the document formatter in VS Code for whitespace/indenting, and undid some to minimize the diff
- Removed some HTML nesting