### PR TITLE
Remove the console log

### DIFF
--- a/src/js/skipto.js
+++ b/src/js/skipto.js
@@ -1326,6 +1326,5 @@
                 window.Wordpress ||
                 ((typeof window.Joomla === 'object' && typeof window.Joomla.getOptions === 'function') ? window.Joomla.getOptions('skipto-settings', {}) : {})
                 );
-    console.log('SkipTo loaded...'); // jshint ignore:line
   });
 })();

--- a/src/js/skipto.js
+++ b/src/js/skipto.js
@@ -280,7 +280,7 @@
           ) {
           localConfig[name] = appConfigSettings[name];
         } else {
-          console.log('** SkipTo Problem with user configuration option "' + name + '".'); // jshint ignore:line
+          throw new Error('** SkipTo Problem with user configuration option "' + name + '".');
         }
       }
     },


### PR DESCRIPTION
Audit tools like Google Lighthouse complain about anything logged in the console. This PR removes the `SkipTo loaded...` message from the console