### PR TITLE
RTL Seperator

### DIFF
--- a/src/css/SkipTo.template.css
+++ b/src/css/SkipTo.template.css
@@ -159,7 +159,6 @@
   display: block;
   width: auto;
   font-weight: bold;
-  text-align: left;
   border-bottom-width: 1px;
   border-bottom-style: solid;
   border-bottom-color: $menuTextColor;


### PR DESCRIPTION
By removing the text-align from this class the separator is till aligned left on an LTR system but importantly it is now correctly aligned right on an RTL system