### PR TITLE
role menuitem

### DIFF
--- a/src/css/SkipTo.template.css
+++ b/src/css/SkipTo.template.css
@@ -82,19 +82,16 @@
 
 .skip-to [role="menuitem"] {
   padding: 3px;
-  display: block;
   width: auto;
   border-width: 0px;
   border-style: solid;
   color: $menuTextColor;
   background-color: $menuBackgroundColor;
   z-index: 1000;
-
   display: grid;
   overflow-y: auto;
   grid-template-columns: repeat(6, 1.2rem) 1fr;
   grid-column-gap: 2px;
-
   font-size: 1em;
 }
 


### PR DESCRIPTION
You can't have two display properties. This PR removes the first one (display:block) as it will never be used as the second one (display:grid) will always overwrite it