### PR TITLE
add header h1 to heading selector list

### DIFF
--- a/src/js/skipto.js
+++ b/src/js/skipto.js
@@ -85,7 +85,7 @@
 
       // Selectors for landmark and headings sections
       landmarks: 'main, [role="main"], [role="search"], nav, [role="navigation"], aside, [role="complementary"]',
-      headings: 'main h1, [role="main"] h1, main h2, [role="main"] h2',
+      headings: 'header h1, [role="banner"] h1, main h1, [role="main"] h1, main h2, [role="main"] h2',
 
       // Custom CSS position and colors
       colorTheme: '',


### PR DESCRIPTION
Hello, here is my PR as per issue #101. 

Adding **header h1** and **[role="banner"] h1** so that SkipTo can detect h1 element in the banner landmark. Thanks!