### PR TITLE
chore: update bower description to 140 chars

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "authors": [
     "PayPal Accessibility Team and DRES Accessible IT Group at the University of Illinois"
   ],
-  "description": "This plugin provides a dynamically-generated drop-down menu that allows keyboard and screen reader users to skip to the most important places on the webpage.",
+  "description": "A plugin providing a dynamically-generated drop-down menu that allows keyboard and screen reader users to skip to the most important places.",
   "main": "downloads/js/skipto.js",
   "keywords": [
     "accessibility",


### PR DESCRIPTION
VScode was flagging that the schema only allows 140 characters for this property. Not sure if it just truncates one publishing or not